### PR TITLE
Feature: Tune gameplay mechanics for power, spin, and sweeping

### DIFF
--- a/curling.html
+++ b/curling.html
@@ -18,6 +18,11 @@
             <span style="color: #4299e1;">Blue: <span id="score-blue">0</span></span>
         </div>
         <button id="resetButton">New Game</button>
+        <div id="sweepControls" style="display: none;">
+            <button id="sweepLeftButton">Sweep Left</button>
+            <button id="sweepCenterButton">Sweep Center</button>
+            <button id="sweepRightButton">Sweep Right</button>
+        </div>
     </div>
 
     <canvas id="gameCanvas" width="800" height="400"></canvas>


### PR DESCRIPTION
Implements several enhancements to curling game controls and feel:

1.  **Power Calibration:**
    *   Increased `POWER_MULTIPLIER` from 0.06 to 0.1 to provide more impactful shots. 100% power should now allow stones to travel through the house, and ~50% power should be sufficient to clear the far hog line.

2.  **Spin Control:**
    *   Changed spin input from horizontal mouse movement to vertical mouse movement during the "aimingCurl" phase.
    *   Mouse movement upwards results in Counter-Clockwise spin.
    *   Mouse movement downwards results in Clockwise spin.
    *   Updated curl physics and trajectory projection to match this new input method and ensure intuitive curl behavior (CW curls right, CCW curls left relative to stone's path).

3.  **Sweeping Mechanism:**
    *   Replaced keyboard-based sweeping with three on-screen buttons: "Sweep Left", "Sweep Center", and "Sweep Right".
    *   These buttons are visible only when a stone is sliding.
    *   Each click provides an instantaneous effect:
        *   "Sweep Left": Small speed boost + lateral nudge to the stone's left.
        *   "Sweep Right": Small speed boost + lateral nudge to the stone's right.
        *   "Sweep Center": Slightly larger speed boost, no lateral nudge.
    *   Removed old continuous sweeping logic and keyboard event listeners.

These changes aim to address user feedback regarding shot power, intuitive spin control, and a more interactive and controllable sweeping system. Constants for these new mechanics have been initialized and may require further fine-tuning based on playtesting.